### PR TITLE
Add MicroBadger badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A Docker image for Airbnb's Caravel data visualization platform.
 
 [![](https://img.shields.io/docker/pulls/aspir/caravel-docker.svg)](https://hub.docker.com/r/aspir/caravel-docker "Click to view the image on Docker Hub")
-[![](https://img.shields.io/docker/automated/aspir/caravel-docker.svg)](https://hub.docker.com/r/aspir/caravel-docker)
+[![](https://img.shields.io/docker/automated/aspir/caravel-docker.svg)](https://hub.docker.com/r/aspir/caravel-docker) [![](https://images.microbadger.com/badges/image/aspir/caravel-docker.svg)](https://microbadger.com/images/aspir/caravel-docker "Get your own image badge on microbadger.com")
 [![Documentation](https://img.shields.io/badge/docs-airbnb.io-blue.svg)](http://airbnb.io/caravel/)
 
 ## Setup
@@ -34,3 +34,4 @@ The official documentation is available here:
           --env SQLALCHEMY_DATABASE_URI="mysql://user:pass@host:port/db" \
           <your username>/caravel
 ```
+ 


### PR DESCRIPTION
We saw your image on Docker Hub at [aspir/caravel-docker](https://hub.docker.com/r/aspir/caravel-docker/), and we thought you might like this badge for your GitHub readme showing the image contents.

The badge shows the number of layers and download size of your Docker image, and links to our site where you can see the [contents of each layer](https://microbadger.com/images/aspir/caravel-docker).

As you're using an automated build it will also show up in your Docker Hub description.

[![](https://images.microbadger.com/badges/image/aspir/caravel-docker.svg)](https://microbadger.com/images/aspir/caravel-docker "Get your own image badge on microbadger.com")
